### PR TITLE
Allow overriding _addDescriptor

### DIFF
--- a/Extend/Model/PaymentGateway.php
+++ b/Extend/Model/PaymentGateway.php
@@ -81,7 +81,7 @@ class PaymentGateway extends BaseModel
      *
      * @since 1.0.0
      */
-    private static function _addDescriptor(&$oTransaction, $sOrderId)
+    protected static function _addDescriptor(&$oTransaction, $sOrderId)
     {
         $sShopId = Registry::getConfig()->getShopId();
         $oShop = oxNew(Shop::class);
@@ -145,7 +145,7 @@ class PaymentGateway extends BaseModel
         }
 
         if ($oPaymentMethod->getPayment()->oxpayments__wdoxidee_descriptor->value) {
-            self::_addDescriptor($oTransaction, $oOrder->oxorder__oxid->value);
+            static::_addDescriptor($oTransaction, $oOrder->oxorder__oxid->value);
         }
 
         if ($this->_shouldAddBasketInfo($oPaymentMethod)) {


### PR DESCRIPTION
Although the method's description says otherwise `_addDescriptor` is currently not overridable since its visibility is `private` and is called with the `self` keyword.